### PR TITLE
Fix name variables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Simply use with 'rhc' client tools - rhc cartridge add https://raw.githubusercon
 The `cassandra` cartridge provides several environment variables to reference for ease
 of use:
 
-    OPENSHIFT_CASSANDRA_HOST      The Cassandra IP address
-    OPENSHIFT_CASSANDRA_PORT      The Cassandra port
-    OPENSHIFT_CASSANDRA_LOG_DIR     The path to the Cassandra log directory
+    OPENSHIFT_CASSANDRA_DB_HOST      The Cassandra IP address
+    OPENSHIFT_CASSANDRA_DB_PORT      The Cassandra port
+    OPENSHIFT_CASSANDRA_DB_LOG_DIR     The path to the Cassandra log directory
     OPENSHIFT_CASSANDRA_NATIVE_TRANSPORT_PORT Port for connecting with java client, on NATIVE TRANSPORT
 
 For more information about environment variables, consult the


### PR DESCRIPTION
Hi Rajat,

a very simple improvement: there was an error in the README, about the name of the exported variables. Now should be ok.
Thanks Massimo
